### PR TITLE
Handle raw emoji_id format in Bubble POST request data

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ Flask==3.0.0
 mutagen==1.47.0
 python-dotenv==1.0.0
 requests==2.31.0
-yt-dlp==2024.03.10
+yt-dlp==2024.11.04
 APScheduler==3.10.4
 ffmpeg==1.4

--- a/src/app.py
+++ b/src/app.py
@@ -157,16 +157,28 @@ def index():
     streams = [os.path.splitext(file)[0] for file in os.listdir(playlist_directory) if file.endswith('.m3u')]
     return render_template("index.html", streams=streams)
 
-def extract_emoji_id(emoji_id_str):
+def extract_emoji_id(emoji_id_input):
     # This function is necessary as long as we're receiving `emoji_id` values from Bubble bot that
     # are inside of angle brackets, which is the raw data format vs the id number itself
-    if not emoji_id_str:
+
+    # Handle None case
+    if not emoji_id_input:
         return None
-    # Check if it's in Discord format <:name:id> or <a:name:id>
-    if emoji_id_str.startswith('<') and emoji_id_str.endswith('>'):
-        # Extract the last part after the last colon
-        return emoji_id_str.split(':')[-1][:-1]
-    return emoji_id_str
+    
+    # If it's already an integer, return it
+    if isinstance(emoji_id_input, int):
+        return emoji_id_input
+        
+    # If it's a string in Discord format <:name:id> or <a:name:id>
+    if isinstance(emoji_id_input, str):
+        if emoji_id_input.startswith('<') and emoji_id_input.endswith('>'):
+            # Extract the last part after the last colon and convert to int
+            return int(emoji_id_input.split(':')[-1][:-1])
+        # If it's a numeric string, convert to int
+        elif emoji_id_input.isdigit():
+            return int(emoji_id_input)
+    
+    raise ValueError(f"Invalid emoji_id format: {emoji_id_input}")
 
 if __name__ == "__main__":
     start_scheduling()

--- a/src/app.py
+++ b/src/app.py
@@ -77,8 +77,8 @@ def add_song():
     channel_id = data.get('channel_id')
     server_id = data.get('server_id')
     emoji_name = data.get('emoji_name')
-    emoji_id = data.get('emoji_id')
- 
+    emoji_id = extract_emoji_id(data.get('emoji_id'))
+    
     result = download_audio(url, user, timestamp, channel_id, server_id, emoji_name, emoji_id)
     
     if result != "Success":
@@ -156,6 +156,17 @@ def index():
     # Name streams based on playlist file names
     streams = [os.path.splitext(file)[0] for file in os.listdir(playlist_directory) if file.endswith('.m3u')]
     return render_template("index.html", streams=streams)
+
+def extract_emoji_id(emoji_id_str):
+    # This function is necessary as long as we're receiving `emoji_id` values from Bubble bot that
+    # are inside of angle brackets, which is the raw data format vs the id number itself
+    if not emoji_id_str:
+        return None
+    # Check if it's in Discord format <:name:id> or <a:name:id>
+    if emoji_id_str.startswith('<') and emoji_id_str.endswith('>'):
+        # Extract the last part after the last colon
+        return emoji_id_str.split(':')[-1][:-1]
+    return emoji_id_str
 
 if __name__ == "__main__":
     start_scheduling()


### PR DESCRIPTION
At some point, the data being received by Bubble-radio from Bubble changed from something like this:

```
data = {
    "url": song_url,
    "user": "test_user",
    "timestamp": timestamp,
    "channel_id": 987654321,
    "server_id": 123456789,
    "emoji_name": emoji_name,
    "emoji_id": 123456789
}
```

to this:

```
data = {
    "url": song_url,
    "user": "test_user",
    "timestamp": timestamp,
    "channel_id": 987654321,
    "server_id": 123456789,
    "emoji_name": emoji_name,
    "emoji_id": <:emoji_name:123456789>
}
```

Note the difference in the final element `emoji_id`: from id value `123456789` to raw string `<:emoji_name:123456789>`

When this change happened, Bubble-radio began writing the raw string to the database for each new song instead of just the id numbers. This caused values like `<:_:1217466244350083072>` and `<a:_:1142194662774415441>` (an animated emoji, hence the preceding `a`) to enter our database.

Our playlist creation logic in `start_streams.sh` then took these strings at face value and tried to construct new playlists for the combination of these string values and `emoji_name`s in the database. This resulted in competing calls to create new playlists that cascaded into some kind of infinite loop, ballooning log files, etc.

Our new function `extract_emoji_id` extracts the integer from the new string format. This should resolve the issue. At some point it might be good to look into why the format sent by Bubble bot has changed -- if it was an API level change, or something internal to Bubble, etc.

Also wrapped in an update to the `yt-dlp` dependency to stay up to date.